### PR TITLE
Escapes Regexp expressions in hostnames

### DIFF
--- a/lib/rack/allowed_hosts.rb
+++ b/lib/rack/allowed_hosts.rb
@@ -64,7 +64,7 @@ module Rack
       if part == '*'
         /.*/
       else
-        part
+        Regexp.quote(part)
       end
     end
   end

--- a/spec/allowed_hosts_spec.rb
+++ b/spec/allowed_hosts_spec.rb
@@ -36,6 +36,29 @@ describe Rack::AllowedHosts do
       pattern = instance.matcher_for('*.example.com')
       expect(pattern.match('www.example.com')).not_to be_nil
     end
+
+    context 'with rejex in strings' do
+      it 'doesn’t treat periods as wildcards' do
+        pattern = instance.matcher_for('abc.def.com')
+        expect(pattern.match('abc-def.com')).to be_nil
+      end
+
+      it 'ignores "*" from rejex' do
+        pattern = instance.matcher_for('abc*.def.com')
+        expect(pattern.match('abcc.def.com')).to be_nil
+      end
+
+      it 'ignored "?" from rejex' do
+        pattern = instance.matcher_for('abc?.def.com')
+        expect(pattern.match('abc.def.com')).to be_nil
+        expect(pattern.match('ab.def.com')).to be_nil
+      end
+
+      it 'ignores parentheses in rejex' do
+        pattern = instance.matcher_for('ab(c).def.com')
+        expect(pattern.match('abc.def.com')).to be_nil
+      end
+    end
   end
 
   context '#host_allowed?' do


### PR DESCRIPTION
Previously, hostnames with valid **Regexp** content would be interpreted as **Regexp** rather than as literal strings. Since users are not aware of this, we should not interpret these strings as **Regexp**.

For example, previously:

```
"app*.mydomain.com"
```

would match things like `"appppppppppp.mydomain.com"` and `"ap.mydomain.com"` which would be irregular behavior.