### PR TITLE
Return forbidden response when host header is not specified

### DIFF
--- a/lib/rack/allowed_hosts.rb
+++ b/lib/rack/allowed_hosts.rb
@@ -4,6 +4,8 @@ require 'rack/allowed_hosts/version'
 module Rack
   class AllowedHosts
 
+    FORBIDDEN_RESPONSE = [403, {'Content-Type' => 'text/html'}, ['<h1>403 Forbidden</h1>']]
+
     attr_reader :allowed_hosts
 
     def initialize(app, &block)
@@ -27,14 +29,20 @@ module Rack
     end
 
     def call(env)
+      http_host = env['HTTP_HOST']
+
+      unless http_host.nil?
+        http_host = http_host.split(':').first
+      end
+
       host_values = [
-        env['HTTP_HOST'].split(':').first,
+        http_host,
         env['SERVER_NAME']
       ].uniq
 
       host_values.each do |host|
         unless host_allowed?(host)
-          return [403, {'Content-Type' => 'text/html'}, ['<h1>403 Forbidden</h1>']]
+          return FORBIDDEN_RESPONSE
         end
       end
 

--- a/rack-allowed_hosts.gemspec
+++ b/rack-allowed_hosts.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |s|
   s.date         = '2015-08-16'
 
   s.add_development_dependency "rspec"
-
+  s.add_development_dependency "pry"
+  s.add_development_dependency "pry-byebug"
 end

--- a/spec/allowed_hosts_spec.rb
+++ b/spec/allowed_hosts_spec.rb
@@ -139,4 +139,34 @@ describe Rack::AllowedHosts do
     end
   end
 
+  context 'call' do
+    let (:app) { double }
+    let(:instance) do
+      Rack::AllowedHosts.new(app) do
+        allow 'example.com'
+      end
+    end
+
+    context 'when HTTP_HOST and SERVER_NAME are nil' do
+      it 'returns the forbidden response' do
+        expect(app).to_not receive(:call)
+        expect(instance.call({})).to eq Rack::AllowedHosts::FORBIDDEN_RESPONSE
+      end
+    end
+
+    context 'when the host header is not an allowed host' do
+      it 'returns the forbidden response' do
+        expect(app).to_not receive(:call)
+        expect(instance.call({ 'HTTP_HOST' => 'someotherdomain.com', 'SERVER_NAME' => 'someotherdomain.com' })).to eq Rack::AllowedHosts::FORBIDDEN_RESPONSE
+      end
+    end
+
+    context 'when the host header is an allowed host' do
+      it 'calls the next rack middleware' do
+        expect(app).to receive(:call)
+
+        instance.call({ 'HTTP_HOST' => 'example.com', 'SERVER_NAME' => 'example.com' })
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'bundler/setup'
+require 'pry'
 Bundler.setup
 
 require 'rack/allowed_hosts'


### PR DESCRIPTION
Our rails app is throwing exceptions when pen testers make requests that don't contain a Host header